### PR TITLE
Remove redundant dune constraint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,6 @@
   (synopsis "Fast, safe mutable dynamic arrays")
   (description "This library provides efficient dynamic arrays with Rust-like mutability permissions.")
   (depends
-    (dune (>= 2.8))
     (ocaml (>= "4.08.0"))
     (odoc :with-doc)
     (ounit2 :with-test)))


### PR DESCRIPTION
With `(lang dune 2.8)`, dune already inserts `"dune" {>= "2.8"}` to the dependencies. This would insert it twice `"dune" {>= "2.8" & >= "2.8"}` which is unnecessary